### PR TITLE
Add CJS dist alongside ESM

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -34,6 +34,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: node --input-type=module -e "import { Table, Query } from './dist/module.js'; const t = new Table('t', 'pk'); const q = new Query(t); q.where.hash.eq('x'); if (!q.toDynamo().TableName) process.exit(1);"
+      - run: node -e "const { Table, Query } = require('./dist/module.cjs'); const t = new Table('t', 'pk'); const q = new Query(t); q.where.hash.eq('x'); if (!q.toDynamo().TableName) process.exit(1);"
 
   publish-gpr:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.1
+
+### Added
+
+- CommonJS build output (`dist/module.cjs`) alongside the existing ESM bundle.
+- `main` and `exports.require` entries in `package.json` for `require()` consumers.
+- CJS type declarations at `dist/module.d.cts`.
+
 ## 0.2.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -34,8 +34,17 @@ npm install @jspreddy/torq
 
 
 ## Available Imports
+
+ESM:
+
 ```js
 import { Index, Table, Query, Operation, DdbType } from '@jspreddy/torq';
+```
+
+CommonJS:
+
+```js
+const { Index, Table, Query, Operation, DdbType } = require('@jspreddy/torq');
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@jspreddy/torq",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.678.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jspreddy/torq",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jspreddy/torq",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SQL Like query builder for dynamodb.",
   "author": "Sai Phaninder Reddy Jonnala",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,19 @@
   "author": "Sai Phaninder Reddy Jonnala",
   "license": "MIT",
   "type": "module",
+  "main": "dist/module.cjs",
   "module": "dist/module.js",
   "types": "dist/module.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/module.d.ts",
-      "import": "./dist/module.js"
+      "import": {
+        "types": "./dist/module.d.ts",
+        "default": "./dist/module.js"
+      },
+      "require": {
+        "types": "./dist/module.d.cts",
+        "default": "./dist/module.cjs"
+      }
     }
   },
   "repository": {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: { module: 'src/index.ts' },
-  format: 'esm',
+  format: ['esm', 'cjs'],
   target: 'node18',
   outDir: 'dist',
   platform: 'node',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a CommonJS build output alongside the existing ESM bundle so consumers can use `require()` as well as `import`.

## Changes

- **Build**: `tsdown.config.ts` now emits both `esm` and `cjs` formats
- **Package exports**: Added `main`, `exports.require`, and matching `.d.cts` types for CJS consumers
- **CI**: Added a smoke test that loads the CJS bundle via `require('./dist/module.cjs')`

## Output files

| Format | JS | Types |
|--------|-----|-------|
| ESM | `dist/module.js` | `dist/module.d.ts` |
| CJS | `dist/module.cjs` | `dist/module.d.cts` |

## Usage

```js
// ESM
import { Table, Query } from '@jspreddy/torq';

// CJS
const { Table, Query } = require('@jspreddy/torq');
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fc92ebb-077b-460e-96d8-14471a24eb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fc92ebb-077b-460e-96d8-14471a24eb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

